### PR TITLE
✨ Introduce PickerPlatformSettings to enable JVM targets to handle the parent window

### DIFF
--- a/picker-compose/build.gradle.kts
+++ b/picker-compose/build.gradle.kts
@@ -53,6 +53,10 @@ kotlin {
             api(projects.pickerCore)
         }
 
+        jvmMain.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
         }

--- a/picker-compose/src/commonMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.kt
+++ b/picker-compose/src/commonMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.picker.core.Picker
+import io.github.vinceglb.picker.core.PickerPlatformSettings
 import io.github.vinceglb.picker.core.PickerSelectionMode
 import io.github.vinceglb.picker.core.PickerSelectionType
 import io.github.vinceglb.picker.core.PlatformDirectory
@@ -18,6 +19,7 @@ public fun <Out> rememberFilePickerLauncher(
     mode: PickerSelectionMode<Out>,
     title: String? = null,
     initialDirectory: String? = null,
+    platformSettings: PickerPlatformSettings? = null,
     onResult: (Out?) -> Unit,
 ): PickerResultLauncher {
     // Init picker
@@ -45,6 +47,7 @@ public fun <Out> rememberFilePickerLauncher(
                     mode = currentMode,
                     title = currentTitle,
                     initialDirectory = currentInitialDirectory,
+                    platformSettings = platformSettings,
                 )
                 currentOnResult(result)
             }
@@ -59,6 +62,7 @@ public fun rememberFilePickerLauncher(
     type: PickerSelectionType = PickerSelectionType.File(),
     title: String? = null,
     initialDirectory: String? = null,
+    platformSettings: PickerPlatformSettings? = null,
     onResult: (PlatformFile?) -> Unit,
 ): PickerResultLauncher {
     return rememberFilePickerLauncher(
@@ -66,6 +70,7 @@ public fun rememberFilePickerLauncher(
         mode = PickerSelectionMode.Single,
         title = title,
         initialDirectory = initialDirectory,
+        platformSettings = platformSettings,
         onResult = onResult,
     )
 }
@@ -74,6 +79,7 @@ public fun rememberFilePickerLauncher(
 public fun rememberDirectoryPickerLauncher(
     title: String? = null,
     initialDirectory: String? = null,
+    platformSettings: PickerPlatformSettings? = null,
     onResult: (PlatformDirectory?) -> Unit,
 ): PickerResultLauncher {
     // Init picker
@@ -97,6 +103,7 @@ public fun rememberDirectoryPickerLauncher(
                 val result = picker.pickDirectory(
                     title = currentTitle,
                     initialDirectory = currentInitialDirectory,
+                    platformSettings = platformSettings,
                 )
                 currentOnResult(result)
             }
@@ -108,6 +115,7 @@ public fun rememberDirectoryPickerLauncher(
 
 @Composable
 public fun rememberFileSaverLauncher(
+    platformSettings: PickerPlatformSettings? = null,
     onResult: (PlatformFile?) -> Unit
 ): SaverResultLauncher {
     // Init picker
@@ -131,6 +139,7 @@ public fun rememberFileSaverLauncher(
                     baseName = baseName,
                     extension = extension,
                     initialDirectory = initialDirectory,
+                    platformSettings = platformSettings,
                 )
                 currentOnResult(result)
             }

--- a/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
+++ b/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
@@ -1,0 +1,67 @@
+package io.github.vinceglb.picker.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.FrameWindowScope
+import io.github.vinceglb.picker.core.PickerPlatformSettings
+import io.github.vinceglb.picker.core.PickerSelectionMode
+import io.github.vinceglb.picker.core.PickerSelectionType
+import io.github.vinceglb.picker.core.PlatformDirectory
+import io.github.vinceglb.picker.core.PlatformFile
+
+@Composable
+public fun <Out> FrameWindowScope.rememberFilePickerLauncher(
+    type: PickerSelectionType = PickerSelectionType.File(),
+    mode: PickerSelectionMode<Out>,
+    title: String? = null,
+    initialDirectory: String? = null,
+    onResult: (Out?) -> Unit,
+) {
+    rememberFilePickerLauncher(
+        type = type,
+        mode = mode,
+        title = title,
+        initialDirectory = initialDirectory,
+        platformSettings = PickerPlatformSettings(this.window),
+        onResult = onResult,
+    )
+}
+
+@Composable
+public fun FrameWindowScope.rememberFilePickerLauncher(
+    type: PickerSelectionType = PickerSelectionType.File(),
+    title: String? = null,
+    initialDirectory: String? = null,
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher {
+    return rememberFilePickerLauncher(
+        type = type,
+        title = title,
+        initialDirectory = initialDirectory,
+        platformSettings = PickerPlatformSettings(this.window),
+        onResult = onResult,
+    )
+}
+
+@Composable
+public fun FrameWindowScope.rememberDirectoryPickerLauncher(
+    title: String? = null,
+    initialDirectory: String? = null,
+    onResult: (PlatformDirectory?) -> Unit,
+) {
+    rememberDirectoryPickerLauncher(
+        title = title,
+        initialDirectory = initialDirectory,
+        platformSettings = PickerPlatformSettings(this.window),
+        onResult = onResult,
+    )
+}
+
+@Composable
+public fun FrameWindowScope.rememberFileSaverLauncher(
+    onResult: (PlatformFile?) -> Unit,
+) {
+    rememberFileSaverLauncher(
+        platformSettings = PickerPlatformSettings(this.window),
+        onResult = onResult,
+    )
+}

--- a/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
+++ b/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
@@ -15,8 +15,8 @@ public fun <Out> FrameWindowScope.rememberFilePickerLauncher(
     title: String? = null,
     initialDirectory: String? = null,
     onResult: (Out?) -> Unit,
-) {
-    rememberFilePickerLauncher(
+): PickerResultLauncher {
+    return rememberFilePickerLauncher(
         type = type,
         mode = mode,
         title = title,
@@ -47,8 +47,8 @@ public fun FrameWindowScope.rememberDirectoryPickerLauncher(
     title: String? = null,
     initialDirectory: String? = null,
     onResult: (PlatformDirectory?) -> Unit,
-) {
-    rememberDirectoryPickerLauncher(
+): PickerResultLauncher {
+    return rememberDirectoryPickerLauncher(
         title = title,
         initialDirectory = initialDirectory,
         platformSettings = PickerPlatformSettings(this.window),
@@ -59,8 +59,8 @@ public fun FrameWindowScope.rememberDirectoryPickerLauncher(
 @Composable
 public fun FrameWindowScope.rememberFileSaverLauncher(
     onResult: (PlatformFile?) -> Unit,
-) {
-    rememberFileSaverLauncher(
+): SaverResultLauncher {
+    return rememberFileSaverLauncher(
         platformSettings = PickerPlatformSettings(this.window),
         onResult = onResult,
     )

--- a/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
+++ b/picker-compose/src/jvmMain/kotlin/io/github/vinceglb/picker/compose/PickerCompose.jvm.kt
@@ -1,7 +1,7 @@
 package io.github.vinceglb.picker.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.WindowScope
 import io.github.vinceglb.picker.core.PickerPlatformSettings
 import io.github.vinceglb.picker.core.PickerSelectionMode
 import io.github.vinceglb.picker.core.PickerSelectionType
@@ -9,7 +9,7 @@ import io.github.vinceglb.picker.core.PlatformDirectory
 import io.github.vinceglb.picker.core.PlatformFile
 
 @Composable
-public fun <Out> FrameWindowScope.rememberFilePickerLauncher(
+public fun <Out> WindowScope.rememberFilePickerLauncher(
     type: PickerSelectionType = PickerSelectionType.File(),
     mode: PickerSelectionMode<Out>,
     title: String? = null,
@@ -27,7 +27,7 @@ public fun <Out> FrameWindowScope.rememberFilePickerLauncher(
 }
 
 @Composable
-public fun FrameWindowScope.rememberFilePickerLauncher(
+public fun WindowScope.rememberFilePickerLauncher(
     type: PickerSelectionType = PickerSelectionType.File(),
     title: String? = null,
     initialDirectory: String? = null,
@@ -43,7 +43,7 @@ public fun FrameWindowScope.rememberFilePickerLauncher(
 }
 
 @Composable
-public fun FrameWindowScope.rememberDirectoryPickerLauncher(
+public fun WindowScope.rememberDirectoryPickerLauncher(
     title: String? = null,
     initialDirectory: String? = null,
     onResult: (PlatformDirectory?) -> Unit,
@@ -57,7 +57,7 @@ public fun FrameWindowScope.rememberDirectoryPickerLauncher(
 }
 
 @Composable
-public fun FrameWindowScope.rememberFileSaverLauncher(
+public fun WindowScope.rememberFileSaverLauncher(
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher {
     return rememberFileSaverLauncher(

--- a/picker-core/src/androidMain/kotlin/io/github/vinceglb/picker/core/Picker.android.kt
+++ b/picker-core/src/androidMain/kotlin/io/github/vinceglb/picker/core/Picker.android.kt
@@ -31,7 +31,8 @@ public actual object Picker {
         type: PickerSelectionType,
         mode: PickerSelectionMode<Out>,
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = withContext(Dispatchers.IO) {
         // Throw exception if registry is not initialized
         val registry = registry ?: throw PickerNotInitializedException()
@@ -114,7 +115,8 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = withContext(Dispatchers.IO) {
         // Throw exception if registry is not initialized
         val registry = registry ?: throw PickerNotInitializedException()
@@ -139,7 +141,8 @@ public actual object Picker {
         bytes: ByteArray,
         baseName: String,
         extension: String,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? = withContext(Dispatchers.IO) {
         suspendCoroutine { continuation ->
             // Throw exception if registry is not initialized

--- a/picker-core/src/androidMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.android.kt
+++ b/picker-core/src/androidMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.android.kt
@@ -1,0 +1,3 @@
+package io.github.vinceglb.picker.core
+
+public actual class PickerPlatformSettings

--- a/picker-core/src/appleMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.apple.kt
+++ b/picker-core/src/appleMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.apple.kt
@@ -1,0 +1,3 @@
+package io.github.vinceglb.picker.core
+
+public actual class PickerPlatformSettings

--- a/picker-core/src/commonMain/kotlin/io/github/vinceglb/picker/core/Picker.kt
+++ b/picker-core/src/commonMain/kotlin/io/github/vinceglb/picker/core/Picker.kt
@@ -6,11 +6,13 @@ public expect object Picker {
         mode: PickerSelectionMode<Out>,
         title: String? = null,
         initialDirectory: String? = null,
+        platformSettings: PickerPlatformSettings? = null,
     ): Out?
 
     public suspend fun pickDirectory(
         title: String? = null,
         initialDirectory: String? = null,
+        platformSettings: PickerPlatformSettings? = null,
     ): PlatformDirectory?
 
     public fun isDirectoryPickerSupported(): Boolean
@@ -20,6 +22,7 @@ public expect object Picker {
         baseName: String = "file",
         extension: String,
         initialDirectory: String? = null,
+        platformSettings: PickerPlatformSettings? = null,
     ): PlatformFile?
 }
 

--- a/picker-core/src/commonMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.kt
+++ b/picker-core/src/commonMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.kt
@@ -1,0 +1,3 @@
+package io.github.vinceglb.picker.core
+
+public expect class PickerPlatformSettings

--- a/picker-core/src/iosMain/kotlin/io/github/vinceglb/picker/core/Picker.ios.kt
+++ b/picker-core/src/iosMain/kotlin/io/github/vinceglb/picker/core/Picker.ios.kt
@@ -34,7 +34,8 @@ public actual object Picker {
         type: PickerSelectionType,
         mode: PickerSelectionMode<Out>,
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = when (type) {
         // Use PHPickerViewController for images and videos
         is PickerSelectionType.Image,
@@ -56,7 +57,8 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = callPicker(
         mode = Mode.Directory,
         contentTypes = listOf(UTTypeFolder),
@@ -70,6 +72,7 @@ public actual object Picker {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? = suspendCoroutine { continuation ->
         // Create a picker delegate
         documentPickerDelegate = DocumentPickerDelegate(

--- a/picker-core/src/jsMain/kotlin/io/github/vinceglb/picker/core/Picker.js.kt
+++ b/picker-core/src/jsMain/kotlin/io/github/vinceglb/picker/core/Picker.js.kt
@@ -17,7 +17,8 @@ public actual object Picker {
         type: PickerSelectionType,
         mode: PickerSelectionMode<Out>,
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = withContext(Dispatchers.Default) {
         suspendCoroutine { continuation ->
             // Create input element
@@ -69,7 +70,8 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = withContext(Dispatchers.Default) {
         throw NotImplementedError("Directory selection is not supported on the web")
     }
@@ -81,6 +83,7 @@ public actual object Picker {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? = withContext(Dispatchers.Default) {
         // Create a blob
         val file = File(

--- a/picker-core/src/jsMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.js.kt
+++ b/picker-core/src/jsMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.js.kt
@@ -1,0 +1,3 @@
+package io.github.vinceglb.picker.core
+
+public actual class PickerPlatformSettings

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/Picker.jvm.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/Picker.jvm.kt
@@ -12,7 +12,8 @@ public actual object Picker {
         type: PickerSelectionType,
         mode: PickerSelectionMode<Out>,
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = withContext(Dispatchers.IO) {
         // Filter by extension
         val extensions = when (type) {
@@ -27,13 +28,15 @@ public actual object Picker {
             PickerSelectionMode.Single -> PlatformFilePicker.current.pickFile(
                 title = title,
                 initialDirectory = initialDirectory,
-                fileExtensions = extensions
+                fileExtensions = extensions,
+                parentWindow = platformSettings?.parentWindow,
             )?.let { listOf(PlatformFile(it)) }
 
             PickerSelectionMode.Multiple -> PlatformFilePicker.current.pickFiles(
                 title = title,
                 initialDirectory = initialDirectory,
-                fileExtensions = extensions
+                fileExtensions = extensions,
+                parentWindow = platformSettings?.parentWindow,
             )?.map { PlatformFile(it) }
         }
 
@@ -43,12 +46,14 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = withContext(Dispatchers.IO) {
         // Open native file picker
         val file = PlatformFilePicker.current.pickDirectory(
             title = title,
-            initialDirectory = initialDirectory
+            initialDirectory = initialDirectory,
+            parentWindow = platformSettings?.parentWindow,
         )
 
         // Return result
@@ -66,12 +71,14 @@ public actual object Picker {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? = withContext(Dispatchers.IO) {
         AwtFileSaver.saveFile(
             bytes = bytes,
             baseName = baseName,
             extension = extension,
-            initialDirectory = initialDirectory
+            initialDirectory = initialDirectory,
+            parentWindow = platformSettings?.parentWindow,
         )
     }
 }

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.jvm.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.jvm.kt
@@ -1,0 +1,7 @@
+package io.github.vinceglb.picker.core
+
+import java.awt.Frame
+
+public actual class PickerPlatformSettings(
+    public val parentWindow: Frame? = null,
+)

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.jvm.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.jvm.kt
@@ -1,7 +1,7 @@
 package io.github.vinceglb.picker.core
 
-import java.awt.Frame
+import java.awt.Window
 
 public actual class PickerPlatformSettings(
-    public val parentWindow: Frame? = null,
+    public val parentWindow: Window? = null,
 )

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/PlatformFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/PlatformFilePicker.kt
@@ -5,7 +5,6 @@ import io.github.vinceglb.picker.core.platform.mac.MacOSFilePicker
 import io.github.vinceglb.picker.core.platform.util.Platform
 import io.github.vinceglb.picker.core.platform.util.PlatformUtil
 import io.github.vinceglb.picker.core.platform.windows.WindowsFilePicker
-import java.awt.Frame
 import java.awt.Window
 import java.io.File
 
@@ -14,20 +13,20 @@ internal interface PlatformFilePicker {
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File?
 
 	suspend fun pickFiles(
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): List<File>?
 
 	fun pickDirectory(
 		initialDirectory: String?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File?
 
 	companion object {

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/PlatformFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/PlatformFilePicker.kt
@@ -5,24 +5,29 @@ import io.github.vinceglb.picker.core.platform.mac.MacOSFilePicker
 import io.github.vinceglb.picker.core.platform.util.Platform
 import io.github.vinceglb.picker.core.platform.util.PlatformUtil
 import io.github.vinceglb.picker.core.platform.windows.WindowsFilePicker
+import java.awt.Frame
+import java.awt.Window
 import java.io.File
 
 internal interface PlatformFilePicker {
 	suspend fun pickFile(
-		initialDirectory: String? = null,
-		fileExtensions: List<String>? = null,
-		title: String? = null,
+		initialDirectory: String?,
+		fileExtensions: List<String>?,
+		title: String?,
+		parentWindow: Frame?,
 	): File?
 
 	suspend fun pickFiles(
-		initialDirectory: String? = null,
-		fileExtensions: List<String>? = null,
-		title: String? = null,
+		initialDirectory: String?,
+		fileExtensions: List<String>?,
+		title: String?,
+		parentWindow: Frame?,
 	): List<File>?
 
 	fun pickDirectory(
-		initialDirectory: String? = null,
-		title: String? = null,
+		initialDirectory: String?,
+		title: String?,
+		parentWindow: Frame?,
 	): File?
 
 	companion object {

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
@@ -53,8 +53,11 @@ internal class AwtFilePicker : PlatformFilePicker {
         val dialog = object : FileDialog(parentWindow, title, LOAD) {
             override fun setVisible(value: Boolean) {
                 super.setVisible(value)
-                val result = files?.toList()
-                continuation.resume(result)
+
+                if (value) {
+                    val result = files?.toList()
+                    continuation.resume(result)
+                }
             }
         }
 

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
@@ -4,7 +4,6 @@ import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.awt.FileDialog
 import java.awt.Frame
-import java.awt.Window
 import java.io.File
 import java.io.FilenameFilter
 import kotlin.coroutines.resume

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFilePicker.kt
@@ -4,6 +4,7 @@ import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.awt.FileDialog
 import java.awt.Frame
+import java.awt.Window
 import java.io.File
 import java.io.FilenameFilter
 import kotlin.coroutines.resume
@@ -12,26 +13,34 @@ internal class AwtFilePicker : PlatformFilePicker {
     override suspend fun pickFile(
         initialDirectory: String?,
         fileExtensions: List<String>?,
-        title: String?
+        title: String?,
+        parentWindow: Frame?,
     ): File? = callAwtPicker(
         title = title,
         isMultipleMode = false,
         fileExtensions = fileExtensions,
-        initialDirectory = initialDirectory
+        initialDirectory = initialDirectory,
+        parentWindow = parentWindow
     )?.firstOrNull()
 
     override suspend fun pickFiles(
         initialDirectory: String?,
         fileExtensions: List<String>?,
-        title: String?
+        title: String?,
+        parentWindow: Frame?,
     ): List<File>? = callAwtPicker(
         title = title,
         isMultipleMode = true,
         fileExtensions = fileExtensions,
-        initialDirectory = initialDirectory
+        initialDirectory = initialDirectory,
+        parentWindow = parentWindow
     )
 
-    override fun pickDirectory(initialDirectory: String?, title: String?): File? {
+    override fun pickDirectory(
+        initialDirectory: String?,
+        title: String?,
+        parentWindow: Frame?,
+    ): File? {
         throw UnsupportedOperationException("Directory picker is not supported on Linux yet.")
     }
 
@@ -40,9 +49,9 @@ internal class AwtFilePicker : PlatformFilePicker {
         isMultipleMode: Boolean,
         initialDirectory: String?,
         fileExtensions: List<String>?,
+        parentWindow: Frame?
     ): List<File>? = suspendCancellableCoroutine { continuation ->
-        val parent: Frame? = null
-        val dialog = object : FileDialog(parent, title, LOAD) {
+        val dialog = object : FileDialog(parentWindow, title, LOAD) {
             override fun setVisible(value: Boolean) {
                 super.setVisible(value)
                 val result = files?.toList()

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFileSaver.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFileSaver.kt
@@ -2,8 +2,11 @@ package io.github.vinceglb.picker.core.platform.awt
 
 import io.github.vinceglb.picker.core.PlatformFile
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.awt.Dialog
 import java.awt.FileDialog
 import java.awt.Frame
+import java.awt.Window
+import java.io.File
 import kotlin.coroutines.resume
 
 internal object AwtFileSaver {
@@ -12,18 +15,32 @@ internal object AwtFileSaver {
         baseName: String,
         extension: String,
         initialDirectory: String?,
-        parentWindow: Frame?,
+        parentWindow: Window?,
     ): PlatformFile? = suspendCancellableCoroutine { continuation ->
-        val dialog = object : FileDialog(parentWindow, "Save dialog", SAVE) {
-            override fun setVisible(value: Boolean) {
-                super.setVisible(value)
-
+        fun handleResult(value: Boolean, files: Array<File>?) {
+            if (value) {
                 val file = files?.firstOrNull()?.let {
                     it.writeBytes(bytes)
                     PlatformFile(it)
                 }
-
                 continuation.resume(file)
+            }
+        }
+
+        // Handle parentWindow: Dialog, Frame, or null
+        val dialog = when (parentWindow) {
+            is Dialog -> object : FileDialog(parentWindow, "Save dialog", SAVE) {
+                override fun setVisible(value: Boolean) {
+                    super.setVisible(value)
+                    handleResult(value, files)
+                }
+            }
+
+            else -> object : FileDialog(parentWindow as? Frame, "Save dialog", SAVE) {
+                override fun setVisible(value: Boolean) {
+                    super.setVisible(value)
+                    handleResult(value, files)
+                }
             }
         }
 

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFileSaver.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/awt/AwtFileSaver.kt
@@ -12,9 +12,9 @@ internal object AwtFileSaver {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        parentWindow: Frame?,
     ): PlatformFile? = suspendCancellableCoroutine { continuation ->
-        val parent: Frame? = null
-        val dialog = object : FileDialog(parent, "Save dialog", SAVE) {
+        val dialog = object : FileDialog(parentWindow, "Save dialog", SAVE) {
             override fun setVisible(value: Boolean) {
                 super.setVisible(value)
 

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/mac/MacOSFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/mac/MacOSFilePicker.kt
@@ -3,13 +3,15 @@ package io.github.vinceglb.picker.core.platform.mac
 import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import io.github.vinceglb.picker.core.platform.mac.foundation.Foundation
 import io.github.vinceglb.picker.core.platform.mac.foundation.ID
+import java.awt.Frame
 import java.io.File
 
 internal class MacOSFilePicker : PlatformFilePicker {
 	override suspend fun pickFile(
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
-		title: String?
+		title: String?,
+		parentWindow: Frame?,
 	): File? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.SingleFile,
@@ -22,7 +24,8 @@ internal class MacOSFilePicker : PlatformFilePicker {
 	override suspend fun pickFiles(
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
-		title: String?
+		title: String?,
+		parentWindow: Frame?,
 	): List<File>? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.MultipleFiles,
@@ -34,7 +37,8 @@ internal class MacOSFilePicker : PlatformFilePicker {
 
 	override fun pickDirectory(
 		initialDirectory: String?,
-		title: String?
+		title: String?,
+		parentWindow: Frame?,
 	): File? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.Directories,

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/mac/MacOSFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/mac/MacOSFilePicker.kt
@@ -3,7 +3,7 @@ package io.github.vinceglb.picker.core.platform.mac
 import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import io.github.vinceglb.picker.core.platform.mac.foundation.Foundation
 import io.github.vinceglb.picker.core.platform.mac.foundation.ID
-import java.awt.Frame
+import java.awt.Window
 import java.io.File
 
 internal class MacOSFilePicker : PlatformFilePicker {
@@ -11,7 +11,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.SingleFile,
@@ -25,7 +25,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): List<File>? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.MultipleFiles,
@@ -38,7 +38,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
 	override fun pickDirectory(
 		initialDirectory: String?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File? {
 		return callNativeMacOSPicker(
 			mode = MacOSFilePickerMode.Directories,

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/windows/WindowsFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/windows/WindowsFilePicker.kt
@@ -2,13 +2,15 @@ package io.github.vinceglb.picker.core.platform.windows
 
 import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import io.github.vinceglb.picker.core.platform.windows.api.JnaFileChooser
+import java.awt.Frame
 import java.io.File
 
 internal class WindowsFilePicker : PlatformFilePicker {
 	override suspend fun pickFile(
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
-		title: String?
+		title: String?,
+		parentWindow: Frame?,
 	): File? {
 		val fileChooser = JnaFileChooser()
 
@@ -25,7 +27,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 		}
 
 		// Show file chooser
-		fileChooser.showOpenDialog(null)
+		fileChooser.showOpenDialog(parentWindow)
 
 		// Return selected file
 		return fileChooser.selectedFile
@@ -34,7 +36,8 @@ internal class WindowsFilePicker : PlatformFilePicker {
 	override suspend fun pickFiles(
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
-		title: String?
+		title: String?,
+		parentWindow: Frame?,
 	): List<File>? {
 		val fileChooser = JnaFileChooser()
 
@@ -51,7 +54,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 		}
 
 		// Show file chooser
-		fileChooser.showOpenDialog(null)
+		fileChooser.showOpenDialog(parentWindow)
 
 		// Return selected files
 		return fileChooser.selectedFiles
@@ -59,7 +62,11 @@ internal class WindowsFilePicker : PlatformFilePicker {
 			.ifEmpty { null }
 	}
 
-	override fun pickDirectory(initialDirectory: String?, title: String?): File? {
+	override fun pickDirectory(
+		initialDirectory: String?,
+		title: String?,
+		parentWindow: Frame?,
+	): File? {
 		val fileChooser = JnaFileChooser()
 
 		// Setup file chooser
@@ -75,7 +82,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 		}
 
 		// Show file chooser
-		fileChooser.showOpenDialog(null)
+		fileChooser.showOpenDialog(parentWindow)
 
 		// Return selected directory
 		return fileChooser.selectedFile

--- a/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/windows/WindowsFilePicker.kt
+++ b/picker-core/src/jvmMain/kotlin/io/github/vinceglb/picker/core/platform/windows/WindowsFilePicker.kt
@@ -2,7 +2,7 @@ package io.github.vinceglb.picker.core.platform.windows
 
 import io.github.vinceglb.picker.core.platform.PlatformFilePicker
 import io.github.vinceglb.picker.core.platform.windows.api.JnaFileChooser
-import java.awt.Frame
+import java.awt.Window
 import java.io.File
 
 internal class WindowsFilePicker : PlatformFilePicker {
@@ -10,7 +10,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File? {
 		val fileChooser = JnaFileChooser()
 
@@ -37,7 +37,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 		initialDirectory: String?,
 		fileExtensions: List<String>?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): List<File>? {
 		val fileChooser = JnaFileChooser()
 
@@ -65,7 +65,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 	override fun pickDirectory(
 		initialDirectory: String?,
 		title: String?,
-		parentWindow: Frame?,
+		parentWindow: Window?,
 	): File? {
 		val fileChooser = JnaFileChooser()
 

--- a/picker-core/src/macosMain/kotlin/io/github/vinceglb/picker/core/Picker.macos.kt
+++ b/picker-core/src/macosMain/kotlin/io/github/vinceglb/picker/core/Picker.macos.kt
@@ -12,6 +12,7 @@ public actual object Picker {
         mode: PickerSelectionMode<Out>,
         title: String?,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = callPicker(
         mode = when (mode) {
             is PickerSelectionMode.Single -> Mode.Single
@@ -29,7 +30,8 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = callPicker(
         mode = Mode.Directory,
         title = title,
@@ -44,6 +46,7 @@ public actual object Picker {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? {
         // Create an NSSavePanel
         val nsSavePanel = NSSavePanel()

--- a/picker-core/src/wasmJsMain/kotlin/io/github/vinceglb/picker/core/Picker.wasmJs.kt
+++ b/picker-core/src/wasmJsMain/kotlin/io/github/vinceglb/picker/core/Picker.wasmJs.kt
@@ -19,7 +19,8 @@ public actual object Picker {
         type: PickerSelectionType,
         mode: PickerSelectionMode<Out>,
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): Out? = withContext(Dispatchers.Default) {
         suspendCoroutine { continuation ->
             // Create input element
@@ -71,7 +72,8 @@ public actual object Picker {
 
     public actual suspend fun pickDirectory(
         title: String?,
-        initialDirectory: String?
+        initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformDirectory? = withContext(Dispatchers.Default) {
         throw NotImplementedError("Directory selection is not supported on the web")
     }
@@ -83,6 +85,7 @@ public actual object Picker {
         baseName: String,
         extension: String,
         initialDirectory: String?,
+        platformSettings: PickerPlatformSettings?,
     ): PlatformFile? = withContext(Dispatchers.Default) {
         // Create a byte array
         val array = Uint8Array(bytes.size)

--- a/picker-core/src/wasmJsMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.wasmJs.kt
+++ b/picker-core/src/wasmJsMain/kotlin/io/github/vinceglb/picker/core/PickerPlatformSettings.wasmJs.kt
@@ -1,0 +1,3 @@
+package io.github.vinceglb.picker.core
+
+public actual class PickerPlatformSettings


### PR DESCRIPTION
- [x] Test on Windows if `AwtFilePicker` and `AwtFileSaver` open modally by default.